### PR TITLE
Common 'make-random-string' function between clj and cljs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 /.classpath
 /.project
 /.repl
+*.iml
+/target

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cljs-uuid "0.0.4"
+(defproject cljs-uuid "0.0.5"
   :description "Micro clojure and clojurescript portability lib for uuid creation"
   :url "https://github.com/davesann/cljs-uuid"
   :license {:name "Eclipse Public License"

--- a/src/cljs_uuid/core.clj
+++ b/src/cljs_uuid/core.clj
@@ -7,3 +7,8 @@
 
 (def make-random make-v4)
 
+(defn make-random-string
+    "Returns a UUID as as String. Common method between CLJ and CLJS for generating UUID strings"
+    []
+    (str (make-random)))
+

--- a/src/cljs_uuid/core.cljs
+++ b/src/cljs_uuid/core.cljs
@@ -22,3 +22,8 @@
 ;; backwards compatibility
 (def make-v4 make-random)
 
+(defn make-random-string
+    "Returns a UUID as as String. Common method between CLJ and CLJS for generating UUID strings"
+    []
+    (.-uuid (make-random)))
+


### PR DESCRIPTION
I created a 'make-random-string' function for both the CLJ and CLJS library. Without it, there was no common way to generate a string from the UUID objects, if you had a need for one.
